### PR TITLE
Dont convert non strings

### DIFF
--- a/lib/ex_cypher/props.ex
+++ b/lib/ex_cypher/props.ex
@@ -9,6 +9,8 @@ defmodule ExCypher.Props do
   both nodes and relationships arguments.
   """
 
+  def stringify(nil), do: ""
+
   def stringify(element)
       when is_atom(element),
       do: Atom.to_string(element)
@@ -25,7 +27,10 @@ defmodule ExCypher.Props do
     args =
       props
       |> Enum.into([])
-      |> Enum.map(fn {name, value} -> ~s["#{name}":"#{value}"] end)
+      |> Enum.map(fn
+        {name, value} when is_binary(value) -> ~s["#{name}":"#{value}"]
+        {name, value} -> ~s["#{name}":#{value}]
+      end)
       |> Enum.join(",")
 
     " {#{args}}"

--- a/lib/ex_cypher/relationship.ex
+++ b/lib/ex_cypher/relationship.ex
@@ -24,9 +24,10 @@ defmodule ExCypher.Relationship do
       iex> rel([:Rel], %{year: 1980})
       "[:Rel {\"year\": 1980}]"
   """
+  def rel(), do: rel("")
 
   @spec rel(props :: map()) :: String.t()
-  def rel(props = %{}), do: rel("", [], props)
+  def rel(props = %{}), do: props |> stringify() |> to_rel()
 
   @spec rel(labels :: list(), props :: map()) :: String.t()
   def rel(labels, props = %{})
@@ -39,9 +40,14 @@ defmodule ExCypher.Relationship do
           props :: map()
         ) :: String.t()
   def rel(name, labels \\ [], props \\ %{}) do
-    ["[", name, labels, props, "]"]
+    [name, labels, props]
     |> Enum.map(&stringify/1)
     |> Enum.join()
+    |> to_rel()
+  end
+
+  def to_rel(string) do
+    "[" <> String.trim(string) <> "]"
   end
 
   @doc """

--- a/test/ex_cypher/node_test.exs
+++ b/test/ex_cypher/node_test.exs
@@ -1,0 +1,88 @@
+defmodule ExCypher.NodeTest do
+  use ExUnit.Case
+
+  import Kernel, except: [node: 0, node: 1]
+  import ExCypher.Node
+
+  describe "node/0" do
+    test "returns empty parenthesis" do
+      assert "()" = node()
+    end
+  end
+
+  describe "node/1" do
+    test "returns a node with it's name" do
+      assert "(bob)" = node(:bob)
+    end
+
+    test "returns a labeled node" do
+      assert "(:Person)" = node([:Person])
+    end
+
+    test "returns a node with props" do
+      assert ~S|({"name":"mark"})| = node(%{name: "mark"})
+    end
+
+    test "does not convert integers to strings in props" do
+      assert ~S|({"age":65})| = node(%{age: 65})
+    end
+
+    test "does not convert booleans to strings in props" do
+      assert ~S|({"married":true})| = node(%{married: true})
+    end
+
+    test "returns empty parenthesis when name is nil" do
+      assert "()" = node(nil)
+    end
+
+    test "returns empty parenthesis when labels are empty" do
+      assert "()" = node([])
+    end
+
+    test "returns empty parenthesis when props are empty" do
+      assert "()" = node(%{})
+    end
+  end
+
+  describe "node/2" do
+    test "returns a named and labeled node" do
+      assert "(bob:Person)" = node(:bob, [:Person])
+    end
+
+    test "returns a labeled node with props" do
+      assert "(:Person {\"name\":\"billy\"})" = node([:Person], %{name: "billy"})
+    end
+
+    test "returns a named node with props" do
+      assert "(p {\"name\":\"billy\"})" = node(:p, %{name: "billy"})
+    end
+
+    test "omits the name when it's nil but have labels" do
+      assert "(:Person)" = node(nil, [:Person])
+    end
+
+    test "omits the labels when it's empty but have a name" do
+      assert "(p)" = node(:p, [])
+    end
+
+    test "omits the props when it's empty but have a name" do
+      assert "(p)" = node(:p, %{})
+    end
+
+    test "omits the props when it's empty but have a label" do
+      assert "(:Person)" = node([:Person], %{})
+    end
+  end
+
+  describe "node/3" do
+    test "returns a complete node" do
+      assert ~S|(p:Person {"name":"ellie"})| =
+        node(:p, [:Person], %{name: "ellie"})
+    end
+
+    test "returns a node with multiple props" do
+      assert ~S|(p:Person {"first_name":"jane","last_name":"doe"})| =
+        node(:p, [:Person], %{first_name: "jane", last_name: "doe"})
+    end
+  end
+end

--- a/test/ex_cypher/relationship_test.exs
+++ b/test/ex_cypher/relationship_test.exs
@@ -1,0 +1,87 @@
+defmodule ExCypher.RelationshipTest do
+  use ExUnit.Case
+
+  import ExCypher.Relationship
+
+  describe "rel/0" do
+    test "returns empty parenthesis" do
+      assert "[]" = rel()
+    end
+  end
+
+  describe "rel/1" do
+    test "returns a rel with it's name" do
+      assert "[bob]" = rel(:bob)
+    end
+
+    test "returns a labeled rel" do
+      assert "[:Person]" = rel([:Person])
+    end
+
+    test "returns a rel with props" do
+      assert ~S|[{"name":"mark"}]| = rel(%{name: "mark"})
+    end
+
+    test "does not convert integers to strings in props" do
+      assert ~S|[{"age":65}]| = rel(%{age: 65})
+    end
+
+    test "does not convert booleans to strings in props" do
+      assert ~S|[{"married":true}]| = rel(%{married: true})
+    end
+
+    test "returns empty parenthesis when name is nil" do
+      assert "[]" = rel(nil)
+    end
+
+    test "returns empty parenthesis when labels are empty" do
+      assert "[]" = rel([])
+    end
+
+    test "returns empty parenthesis when props are empty" do
+      assert "[]" = rel(%{})
+    end
+  end
+
+  describe "rel/2" do
+    test "returns a named and labeled rel" do
+      assert "[bob:Person]" = rel(:bob, [:Person])
+    end
+
+    test "returns a labeled rel with props" do
+      assert "[:Person {\"name\":\"billy\"}]" = rel([:Person], %{name: "billy"})
+    end
+
+    test "returns a named rel with props" do
+      assert "[p {\"name\":\"billy\"}]" = rel(:p, %{name: "billy"})
+    end
+
+    test "omits the name when it's nil but have labels" do
+      assert "[:Person]" = rel(nil, [:Person])
+    end
+
+    test "omits the labels when it's empty but have a name" do
+      assert "[p]" = rel(:p, [])
+    end
+
+    test "omits the props when it's empty but have a name" do
+      assert "[p]" = rel(:p, %{})
+    end
+
+    test "omits the props when it's empty but have a label" do
+      assert "[:Person]" = rel([:Person], %{})
+    end
+  end
+
+  describe "rel/3" do
+    test "returns a complete rel" do
+      assert ~S|[p:Person {"name":"ellie"}]| =
+        rel(:p, [:Person], %{name: "ellie"})
+    end
+
+    test "returns a rel with multiple props" do
+      assert ~S|[p:Person {"first_name":"jane","last_name":"doe"}]| =
+        rel(:p, [:Person], %{first_name: "jane", last_name: "doe"})
+    end
+  end
+end


### PR DESCRIPTION
Fixing the props building with non-string values. The old version was taking maps with non-strings and always converting them to strings inside the cypher query (wrapping them on double-quotes).

This new version avoids that.

Fixes #3 