### PR TITLE
Removing quotes from generated queries

### DIFF
--- a/lib/ex_cypher.ex
+++ b/lib/ex_cypher.ex
@@ -5,128 +5,139 @@ defmodule ExCypher do
   This module provide a clean API to build queries using CYPHER query language,
   which is largely used by Neo4j
 
-  ### Usage:
+  ## Usage:
 
   First of all, add `import ExCpyher` to the top of your module, so that
-  `cypher` macro is available to your functions, then you can run it to generate
-  you cypher queries.
+  `ExCypher.cypher/0` macro is available to your functions.
 
-  ### Examples:
+  After that, you can use cypher-friendly functions to build your queries:
 
-  ##### MATCH statements:
+      iex> cypher do: match(node(:n))
+      "MATCH (n)"
 
-  1. Matching nodes without returning a specific property
+      iex> cypher do: match(node(:p, [:Person]))
+      "MATCH (p:Person)"
 
-  ```
-    iex> cypher do: match(node(:n))
-    "MATCH (n)"
+      iex> cypher do
+      ...>   match(node(:p, [:Person], %{name: "bob"}))
+      ...> end
+      ~S[MATCH (p:Person {name:"bob"})]
 
-    iex> cypher do: match(node(:p, [:Person]))
-    "MATCH (p:Person)"
+  Also we support a familiar syntax to build nodes associations, by using either
+  `:--`, `:->` or `:<-` to denote the nodes associations, as follows:
 
-    iex> cypher do
-    ...>   match(node(:p, [:Person], %{name: "bob"}))
-    ...> end
-    ~S[MATCH (p:Person {name:"bob"})]
+      iex> cypher do
+      ...>   match node(:p, [:Person]) -- node(:c, [:Company])
+      ...> end
+      "MATCH (p:Person)--(c:Company)"
 
-  ```
+      iex> cypher do
+      ...>   match node(:p, [:Person]) -- rel(:WORKS_IN) -- node(:c, [:Company])
+      ...>   return :p
+      ...> end
+      "MATCH (p:Person)-[WORKS_IN]-(c:Company) RETURN p"
 
-  We already support associations too:
+      iex> cypher do
+      ...>   match (node(:p, [:Person]) -- rel(:WORKS_IN) -> node(:c, [:Company]))
+      ...> end
+      "MATCH (p:Person)-[WORKS_IN]->(c:Company)"
 
-  ```
-    iex> cypher do
-    ...>   match node(:p, [:Person]) -- node(:c, [:Company])
-    ...> end
-    "MATCH (p:Person)--(c:Company)"
+      iex> cypher do
+      ...>   match (node(:c, [:Company]) <- rel(:WORKS_IN) -- node(:p, [:Person]))
+      ...> end
+      "MATCH (c:Company)<-[WORKS_IN]-(p:Person)"
 
-    iex> cypher do
-    ...>   match node(:p, [:Person]) -- rel(:WORKS_IN) -- node(:c, [:Company])
-    ...>   return :p
-    ...> end
-    "MATCH (p:Person)-[WORKS_IN]-(c:Company) RETURN p"
+  See `ExCypher.Node.node/0` and `ExCypher.Relationship.rel/0` for more
+  information on how to build your nodes and relationships.
 
-  ```
+  If you need to order your returned nodes, you can use both `order` and `limit`:
 
-  Can use arrow-syntax to represent directed associations, but must use
-  parenthesis arround the `match` arguments so that elixir correctly
-  builds the AST with the correct precedence structure
-
-  ```
-    iex> cypher do
-    ...>   match (node(:p, [:Person]) -- rel(:WORKS_IN) -> node(:c, [:Company]))
-    ...> end
-    "MATCH (p:Person)-[WORKS_IN]->(c:Company)"
-
-    iex> cypher do
-    ...>   match (node(:c, [:Company]) <- rel(:WORKS_IN) -- node(:p, [:Person]))
-    ...> end
-    "MATCH (c:Company)<-[WORKS_IN]-(p:Person)"
-
-  ```
-
-  ##### ORDERing and LIMITing queries:
-
-  You can order and/or limit your query results with `order` and `limit`
-  commands:
-
-  ```
-    iex> cypher do
-    ...>   match node(:s, [:Sharks])
-    ...>   order s.name
-    ...>   limit 10
-    ...>   return s.name, s.population
-    ...> end
-    "MATCH (s:Sharks) ORDER BY s.name LIMIT 10 RETURN s.name, s.population"
-
-  ```
+      iex> cypher do
+      ...>   match node(:s, [:Sharks])
+      ...>   order s.name
+      ...>   limit 10
+      ...>   return s.name, s.population
+      ...> end
+      "MATCH (s:Sharks) ORDER BY s.name LIMIT 10 RETURN s.name, s.population"
 
   Also, you can choose the ordering direction of your matched nodes with a
   tuple syntax:
 
-  ```
-    iex> cypher do
-    ...>   match node(:s, [:Sharks])
-    ...>   order {s.name, :asc}, {s.age, :desc}
-    ...>   return :s
-    ...> end
-    "MATCH (s:Sharks) ORDER BY s.name ASC, s.age DESC RETURN s"
+      iex> cypher do
+      ...>   match node(:s, [:Sharks])
+      ...>   order {s.name, :asc}, {s.age, :desc}
+      ...>   return :s
+      ...> end
+      "MATCH (s:Sharks) ORDER BY s.name ASC, s.age DESC RETURN s"
+
+  There're also support for `create` and `merge` statements from cypher
+  language:
+
+      iex> cypher do
+      ...>   create node(:p, [:Player], %{nick: "like4boss", score: 100})
+      ...>   return p.name
+      ...> end
+      ~S[CREATE (p:Player {nick:"like4boss",score:100}) RETURN p.name]
+
+      iex> cypher do
+      ...>   create (node(:c, [:Country], %{name: "Brazil"}) -- rel([:HAS_CITY]) -> node([:City], %{name: "São Paulo"}))
+      ...>   return c
+      ...> end
+      ~S|CREATE (c:Country {name:"Brazil"})-[:HAS_CITY]->(:City {name:"São Paulo"}) RETURN c|
+
+      iex> cypher do
+      ...>   merge node(:p, [:Player], %{nick: "like4boss"})
+      ...>   merge node(:p2, [:Player], %{nick: "marioboss"})
+      ...>   return p.name
+      ...> end
+      ~S|MERGE (p:Player {nick:"like4boss"}) MERGE (p2:Player {nick:"marioboss"}) RETURN p.name|
+
+      iex> cypher do
+      ...>   merge node(:p, [:Player], %{nick: "like4boss"})
+      ...>   merge node(:p2, [:Player], %{nick: "marioboss"})
+      ...>   merge (node(:p) -- rel([:IN_LOBBY]) -> node(:p2))
+      ...>   return p.name
+      ...> end
+      ~S|MERGE (p:Player {nick:"like4boss"}) MERGE (p2:Player {nick:"marioboss"}) MERGE (p)-[:IN_LOBBY]->(p2) RETURN p.name|
+
+  ## Caveats with complex relationships
+
+  Each of the presented elements above are independent functions that work
+  together to build complex cypher queries under the hood. When building complex
+  association between nodes and relationships, you must be aware that in some
+  cases you may end fighting agaisnt elixir compiler when using the `:->`
+  operator, which is reserved to functions and pattern matching.
+
+  This can be solved with a simple caveat specifying a little better the scope
+  of your association. Before diving into this, consider this example:
+
+      iex> cypher do
+      ...>   create node(:p, [:Player], %{name: "mario"}),
+      ...>          node(:p2, [:Player], %{name: "luigi"})
+      ...> end
+      ~S|CREATE (p:Player {name:"mario"}), (p2:Player {name:"luigi"})|
+
+  Each node defined in this query act as an argument to a bigger function.
+  If you want to use an association in this query, you may try the following:
 
   ```
-
-  ##### CREATE and MERGE stuff
-
-  In order to create new nodes into your database, you can use the
-  following syntax:
-
-  ```
-    iex> cypher do
-    ...>   create node(:p, [:Player], %{nick: "like4boss", score: 100})
-    ...>   return p.name
-    ...> end
-    ~S[CREATE (p:Player {nick:"like4boss",score:100}) RETURN p.name]
-
+    cypher do
+      create node(:p, [:Player], %{name: "mario"}),
+             node(:p2, [:Player], %{name: "luigi"}),
+             node(:p) -- rel([:IS_FRIEND]) -> node(:p2)
+    end
   ```
 
-  However, if you want to match pre-existing nodes instead of creating new
-  ones, you can use merge, as follows:
+  But this will result in a compilation error. Instead, let's take care about
+  the operator precedence here and wrap the entire association in parenthesis,
+  this way resolving any conflict made by the compiler:
 
-  ```
-    iex> cypher do
-    ...>   merge node(:p, [:Player], %{nick: "like4boss"})
-    ...>   merge node(:p2, [:Player], %{nick: "marioboss"})
-    ...>   return p.name
-    ...> end
-    ~S|MERGE (p:Player {nick:"like4boss"}) MERGE (p2:Player {nick:"marioboss"}) RETURN p.name|
-
-    iex> cypher do
-    ...>   merge node(:p, [:Player], %{nick: "like4boss"})
-    ...>   merge node(:p2, [:Player], %{nick: "marioboss"})
-    ...>   merge (node(:p) -- rel([:IN_LOBBY]) -> node(:p2))
-    ...>   return p.name
-    ...> end
-    ~S|MERGE (p:Player {nick:"like4boss"}) MERGE (p2:Player {nick:"marioboss"}) MERGE (p)-[:IN_LOBBY]->(p2) RETURN p.name|
-
-  ```
+      iex>  cypher do
+      ...>    create node(:p, [:Player], %{name: "mario"}),
+      ...>           node(:p2, [:Player], %{name: "luigi"}),
+      ...>           (node(:p) -- rel([:IS_FRIEND]) -> node(:p2))
+      ...>  end
+      ~S|CREATE (p:Player {name:"mario"}), (p2:Player {name:"luigi"}), (p)-[:IS_FRIEND]->(p2)|
 
   """
 

--- a/lib/ex_cypher.ex
+++ b/lib/ex_cypher.ex
@@ -27,7 +27,7 @@ defmodule ExCypher do
     iex> cypher do
     ...>   match(node(:p, [:Person], %{name: "bob"}))
     ...> end
-    ~S[MATCH (p:Person {"name":"bob"})]
+    ~S[MATCH (p:Person {name:"bob"})]
 
   ```
 
@@ -100,10 +100,10 @@ defmodule ExCypher do
 
   ```
     iex> cypher do
-    ...>   create node(:p, [:Player], %{nick: "like4boss", score: "100"})
+    ...>   create node(:p, [:Player], %{nick: "like4boss", score: 100})
     ...>   return p.name
     ...> end
-    ~S[CREATE (p:Player {"nick":"like4boss","score":"100"}) RETURN p.name]
+    ~S[CREATE (p:Player {nick:"like4boss",score:100}) RETURN p.name]
 
   ```
 
@@ -116,7 +116,7 @@ defmodule ExCypher do
     ...>   merge node(:p2, [:Player], %{nick: "marioboss"})
     ...>   return p.name
     ...> end
-    ~S|MERGE (p:Player {"nick":"like4boss"}) MERGE (p2:Player {"nick":"marioboss"}) RETURN p.name|
+    ~S|MERGE (p:Player {nick:"like4boss"}) MERGE (p2:Player {nick:"marioboss"}) RETURN p.name|
 
     iex> cypher do
     ...>   merge node(:p, [:Player], %{nick: "like4boss"})
@@ -124,7 +124,7 @@ defmodule ExCypher do
     ...>   merge (node(:p) -- rel([:IN_LOBBY]) -> node(:p2))
     ...>   return p.name
     ...> end
-    ~S|MERGE (p:Player {"nick":"like4boss"}) MERGE (p2:Player {"nick":"marioboss"}) MERGE (p)-[:IN_LOBBY]->(p2) RETURN p.name|
+    ~S|MERGE (p:Player {nick:"like4boss"}) MERGE (p2:Player {nick:"marioboss"}) MERGE (p)-[:IN_LOBBY]->(p2) RETURN p.name|
 
   ```
 

--- a/lib/ex_cypher.ex
+++ b/lib/ex_cypher.ex
@@ -161,25 +161,21 @@ defmodule ExCypher do
     end
   end
 
-  @doc """
-    Saves a query line into the query buffer (where the other query lines)
-    are being kept isolated.
+  # Saves a query line into the query buffer (where the other query lines)
+  # are being kept isolated.
 
-    Since those query lines break with elixir's language syntax, we cannot
-    call `unquote` on them, thus making the macro approach necessary.
+  # Since those query lines break with elixir's language syntax, we cannot
+  # call `unquote` on them, thus making the macro approach necessary.
 
-    Also, `buffer` pid is on another scope, and cannot be accessed directly
-    by the `parse` function.
-  """
+  # Also, `buffer` pid is on another scope, and cannot be accessed directly
+  # by the `parse` function.
   defmacro command(args) do
     quote do
       Buffer.put_buffer(var!(buffer, ExCypher), unquote(args))
     end
   end
 
-  @doc """
-    Parses each command-line from the `cypher` macro's block
-  """
+  # Parses each command-line from the `cypher` macro's block
   def parse({command, _ctx, args}) when command in @supported_statements do
     params = Statement.parse(command, args)
 

--- a/lib/ex_cypher/buffer.ex
+++ b/lib/ex_cypher/buffer.ex
@@ -1,21 +1,21 @@
 defmodule ExCypher.Buffer do
-  @moduledoc """
-    In order to preserve the generated query without conflicts about
-    where the code is being ran, this module implements a small buffer
-    using an `Agent` that keeps a list of all statements that could
-    be parsed.
+  @moduledoc false
 
-    This way, every time one invokes the `cypher` macro, a new agent is
-    started, and every line inside is parsed. Those commands that can
-    be converted into a Cypher command are then parsed and pushed into
-    the agent.
+  # In order to preserve the generated query without conflicts about
+  # where the code is being ran, this module implements a small buffer
+  # using an `Agent` that keeps a list of all statements that could
+  # be parsed.
 
-    At the end, the `ExCypher.Buffer.generate_query/1` function can be
-    called and all lines are joined to build the correct query string.
+  # This way, every time one invokes the `cypher` macro, a new agent is
+  # started, and every line inside is parsed. Those commands that can
+  # be converted into a Cypher command are then parsed and pushed into
+  # the agent.
 
-    But remember that this module shouldn't be used directly by your
-    code!
-  """
+  # At the end, the `ExCypher.Buffer.generate_query/1` function can be
+  # called and all lines are joined to build the correct query string.
+
+  # But remember that this module shouldn't be used directly by your
+  # code!
 
   @spec put_buffer(buffer :: pid(), elements :: term()) ::
           :ok | {:error, term()}

--- a/lib/ex_cypher/node.ex
+++ b/lib/ex_cypher/node.ex
@@ -1,6 +1,6 @@
 defmodule ExCypher.Node do
   @moduledoc """
-  CYPHER node statements
+  Builds nodes using cypher syntax
 
   It can be used in order to build more complex queries involving your
   graph nodes.
@@ -11,24 +11,26 @@ defmodule ExCypher.Node do
   @doc """
   Returns the CYPHER's syntax to a node element.
 
-  ### Example:
+  ### Examples:
 
+      iex> node()
+      "()"
 
-  * Building an empty node:
-    iex> node()
-    "()"
+      iex> node(%{name: "bob"})
+      "({\"name\": \"bob\"})"
 
-  * Building an node with only props:
-    iex> node(%{name: "bob"})
-    "({\"name\": \"bob\"})"
+      iex> node([:Person])
+      "(:Person)"
 
-  * Building a labeled node:
-    iex> node(:a, [:Node])
-    "(a:Node)"
+      iex> node([:Person], %{name: "Amelia"})
+      "(:Person {name: \"Amelia\"})"
 
-  * Building a more complex node (with props and labels):
-    iex> node(:a, [:Node], %{name: "mark", age: 27})
-    "(a:Node {\"name\": \"mark\", \"age\": 27)"
+      iex> node(:a, [:Node])
+      "(a:Node)"
+
+      iex> node(:a, [:Node], %{name: "mark", age: 27})
+      "(a:Node {\"name\": \"mark\", \"age\": 27)"
+
   """
   @spec node() :: String.t()
   def node, do: to_node("")

--- a/lib/ex_cypher/props.ex
+++ b/lib/ex_cypher/props.ex
@@ -1,13 +1,13 @@
 defmodule ExCypher.Props do
-  @moduledoc """
-  Maps and lists doesn't implement the String.Chars protocol,
-  and they'll need also some parsing so that they're compliant
-  with the cypher syntax.
+  @moduledoc false
 
-  This module provides a way to help converting those contents
-  into a cypher-compliant strings that can be used to build
-  both nodes and relationships arguments.
-  """
+  # Maps and lists doesn't implement the String.Chars protocol,
+  # and they'll need also some parsing so that they're compliant
+  # with the cypher syntax.
+
+  # This module provides a way to help converting those contents
+  # into a cypher-compliant strings that can be used to build
+  # both nodes and relationships arguments.
 
   def stringify(nil), do: ""
 

--- a/lib/ex_cypher/props.ex
+++ b/lib/ex_cypher/props.ex
@@ -28,8 +28,8 @@ defmodule ExCypher.Props do
       props
       |> Enum.into([])
       |> Enum.map(fn
-        {name, value} when is_binary(value) -> ~s["#{name}":"#{value}"]
-        {name, value} -> ~s["#{name}":#{value}]
+        {name, value} when is_binary(value) -> ~s[#{name}:"#{value}"]
+        {name, value} -> ~s[#{name}:#{value}]
       end)
       |> Enum.join(",")
 

--- a/lib/ex_cypher/relationship.ex
+++ b/lib/ex_cypher/relationship.ex
@@ -1,6 +1,6 @@
 defmodule ExCypher.Relationship do
   @moduledoc """
-  Mounts Cypher syntax-compliant relationships between nodes.
+  Builds relationships using cypher syntax
   """
   import ExCypher.Props, only: [stringify: 1]
 
@@ -8,22 +8,30 @@ defmodule ExCypher.Relationship do
   @typep node_or_relationship :: String.t()
 
   @doc """
-  Builds Cypher relationship structure given a set of parameters
+  Returns the Cypher's syntax for a relationship:
 
   ### Usage:
 
-  * Building a relationship with params:
+      iex> rel()
+      "[]"
+
       iex> rel(%{year: 1980})
       "[{\"year\": 1980}]"
 
-  * Building a named relationship:
+      iex> rel([:WORKS_IN])
+      "[:WORKS_IN]"
+
       iex> rel(:r, %{year: 1980})
       "[r {\"year\": 1980}]"
 
-  * Building a labeled relationship:
       iex> rel([:Rel], %{year: 1980})
       "[:Rel {\"year\": 1980}]"
+
+      iex> rel(:r, [:Rel], %{year: 1980})
+      "[r:Rel {\"year\": 1980}]"
   """
+
+  @spec rel() :: String.t()
   def rel(), do: rel("")
 
   @spec rel(props :: map()) :: String.t()

--- a/lib/ex_cypher/statement.ex
+++ b/lib/ex_cypher/statement.ex
@@ -1,19 +1,19 @@
 defmodule ExCypher.Statement do
+  @moduledoc false
+
   alias ExCypher.Statements.{Generic, Order, Where}
 
-  @moduledoc """
-    Cypher syntax varies depending on the statement being used. For example,
-    the `WHERE` statement's syntax can vary a lot when compared to simpler
-    `RETURN` statements.
+  # Cypher syntax varies depending on the statement being used. For example,
+  # the `WHERE` statement's syntax can vary a lot when compared to simpler
+  # `RETURN` statements.
 
-    This way, there's no point on creating an extense library with several
-    pattern matching conditions when some of them shouldn't be applied to
-    statements like `RETURN` or `LIMIT`.
+  # This way, there's no point on creating an extense library with several
+  # pattern matching conditions when some of them shouldn't be applied to
+  # statements like `RETURN` or `LIMIT`.
 
-    This module splits the syntax parsing into submodules, making it easier to
-    check, maintain and improve the support to the Cypher language in this
-    library.
-  """
+  # This module splits the syntax parsing into submodules, making it easier to
+  # check, maintain and improve the support to the Cypher language in this
+  # library.
 
   @type command_name :: atom
 

--- a/lib/ex_cypher/statements/generic.ex
+++ b/lib/ex_cypher/statements/generic.ex
@@ -1,24 +1,24 @@
 defmodule ExCypher.Statements.Generic do
-  @moduledoc """
-    This module will provide the most generic AST conversion
-    functions that'll be shared between different commands.
+  @moduledoc false
 
-    Of course, such abstraction won't be possible to match
-    all kinds of statements, because some cypher commands
-    like the `WHERE` statement, have a unique syntax that is
-    very different from simpler ones, like the `RETURN`
-    statement.
+  # This module will provide the most generic AST conversion
+  # functions that'll be shared between different commands.
 
-    The intent, in this way, is to combine functions in a
-    specialization way. Outer modules attempt to filter and
-    process their specific syntaxes and, whenever they can't,
-    use this module as a last attempt to convert those AST
-    nodes.
+  # Of course, such abstraction won't be possible to match
+  # all kinds of statements, because some cypher commands
+  # like the `WHERE` statement, have a unique syntax that is
+  # very different from simpler ones, like the `RETURN`
+  # statement.
 
-    This way the core logic, which can include the caveat arround
-    elixir's function identification on unknown names, for example,
-    can be shared with other modules
-  """
+  # The intent, in this way, is to combine functions in a
+  # specialization way. Outer modules attempt to filter and
+  # process their specific syntaxes and, whenever they can't,
+  # use this module as a last attempt to convert those AST
+  # nodes.
+
+  # This way the core logic, which can include the caveat arround
+  # elixir's function identification on unknown names, for example,
+  # can be shared with other modules
 
   alias ExCypher.{Node, Relationship}
 

--- a/lib/ex_cypher/statements/order.ex
+++ b/lib/ex_cypher/statements/order.ex
@@ -1,14 +1,11 @@
 defmodule ExCypher.Statements.Order do
-  @moduledoc """
-    Parses ORDER statements and provides support
-    for ASC and DESC ordering syntax.
-  """
+  @moduledoc false
+
+  # Parses ORDER statements and provides support
+  # for ASC and DESC ordering syntax.
+
   alias ExCypher.Statements.Generic
 
-  @doc """
-    Provides support to `ASC` and `DESC` syntax in `ORDER BY`
-    statements
-  """
   @spec parse(ast :: term()) :: String.t()
   def parse({term, ordering}) when ordering in [:asc, :desc] do
     direction =

--- a/lib/ex_cypher/statements/where.ex
+++ b/lib/ex_cypher/statements/where.ex
@@ -1,19 +1,14 @@
 defmodule ExCypher.Statements.Where do
-  @moduledoc """
-    Parses WHERE statements into cypher compliant statements, avoiding some
-    changes made by elixir's compiler into the `where` statements
-  """
+  @moduledoc false
+
+  # Parses WHERE statements into cypher compliant statements, avoiding some
+  # changes made by elixir's compiler into the `where` statements
+
   alias ExCypher.Statements.Generic
 
   @logical_operators [:and, :or, :=]
 
-  @doc """
-    Designed to work directly with `Macro.to_string/2`, in which it receives
-    two arguments:
-
-      1. The AST node being parsed
-      2. The original elixir representation for that AST node
-  """
+  @doc false
   @spec parse(ast :: term()) :: String.t()
   def parse({op, _, [first, last | []]})
       when op in @logical_operators do

--- a/test/ex_cypher/node_test.exs
+++ b/test/ex_cypher/node_test.exs
@@ -20,15 +20,15 @@ defmodule ExCypher.NodeTest do
     end
 
     test "returns a node with props" do
-      assert ~S|({"name":"mark"})| = node(%{name: "mark"})
+      assert ~S|({name:"mark"})| = node(%{name: "mark"})
     end
 
     test "does not convert integers to strings in props" do
-      assert ~S|({"age":65})| = node(%{age: 65})
+      assert "({age:65})" = node(%{age: 65})
     end
 
     test "does not convert booleans to strings in props" do
-      assert ~S|({"married":true})| = node(%{married: true})
+      assert ~S|({married:true})| = node(%{married: true})
     end
 
     test "returns empty parenthesis when name is nil" do
@@ -50,11 +50,11 @@ defmodule ExCypher.NodeTest do
     end
 
     test "returns a labeled node with props" do
-      assert "(:Person {\"name\":\"billy\"})" = node([:Person], %{name: "billy"})
+      assert "(:Person {name:\"billy\"})" = node([:Person], %{name: "billy"})
     end
 
     test "returns a named node with props" do
-      assert "(p {\"name\":\"billy\"})" = node(:p, %{name: "billy"})
+      assert "(p {name:\"billy\"})" = node(:p, %{name: "billy"})
     end
 
     test "omits the name when it's nil but have labels" do
@@ -76,12 +76,12 @@ defmodule ExCypher.NodeTest do
 
   describe "node/3" do
     test "returns a complete node" do
-      assert ~S|(p:Person {"name":"ellie"})| =
+      assert ~S|(p:Person {name:"ellie"})| =
         node(:p, [:Person], %{name: "ellie"})
     end
 
     test "returns a node with multiple props" do
-      assert ~S|(p:Person {"first_name":"jane","last_name":"doe"})| =
+      assert ~S|(p:Person {first_name:"jane",last_name:"doe"})| =
         node(:p, [:Person], %{first_name: "jane", last_name: "doe"})
     end
   end

--- a/test/ex_cypher/relationship_test.exs
+++ b/test/ex_cypher/relationship_test.exs
@@ -19,15 +19,15 @@ defmodule ExCypher.RelationshipTest do
     end
 
     test "returns a rel with props" do
-      assert ~S|[{"name":"mark"}]| = rel(%{name: "mark"})
+      assert ~S|[{name:"mark"}]| = rel(%{name: "mark"})
     end
 
     test "does not convert integers to strings in props" do
-      assert ~S|[{"age":65}]| = rel(%{age: 65})
+      assert ~S|[{age:65}]| = rel(%{age: 65})
     end
 
     test "does not convert booleans to strings in props" do
-      assert ~S|[{"married":true}]| = rel(%{married: true})
+      assert ~S|[{married:true}]| = rel(%{married: true})
     end
 
     test "returns empty parenthesis when name is nil" do
@@ -49,11 +49,11 @@ defmodule ExCypher.RelationshipTest do
     end
 
     test "returns a labeled rel with props" do
-      assert "[:Person {\"name\":\"billy\"}]" = rel([:Person], %{name: "billy"})
+      assert "[:Person {name:\"billy\"}]" = rel([:Person], %{name: "billy"})
     end
 
     test "returns a named rel with props" do
-      assert "[p {\"name\":\"billy\"}]" = rel(:p, %{name: "billy"})
+      assert "[p {name:\"billy\"}]" = rel(:p, %{name: "billy"})
     end
 
     test "omits the name when it's nil but have labels" do
@@ -75,12 +75,12 @@ defmodule ExCypher.RelationshipTest do
 
   describe "rel/3" do
     test "returns a complete rel" do
-      assert ~S|[p:Person {"name":"ellie"}]| =
+      assert ~S|[p:Person {name:"ellie"}]| =
         rel(:p, [:Person], %{name: "ellie"})
     end
 
     test "returns a rel with multiple props" do
-      assert ~S|[p:Person {"first_name":"jane","last_name":"doe"}]| =
+      assert ~S|[p:Person {first_name:"jane",last_name:"doe"}]| =
         rel(:p, [:Person], %{first_name: "jane", last_name: "doe"})
     end
   end

--- a/test/ex_cypher_test.exs
+++ b/test/ex_cypher_test.exs
@@ -37,7 +37,7 @@ defmodule ExCypherTest do
           match(node([:Node], %{name: "foo"}))
         end
 
-      assert ~S[MATCH (:Node {"name":"foo"})] = query
+      assert ~S[MATCH (:Node {name:"foo"})] = query
     end
 
     test "with a name and a multiple labels" do
@@ -55,7 +55,7 @@ defmodule ExCypherTest do
           match(node(:bob, [], %{name: "Bob"}))
         end
 
-      assert ~S[MATCH (bob {"name":"Bob"})] == query
+      assert ~S[MATCH (bob {name:"Bob"})] == query
     end
 
     test "with a name and lots of props" do
@@ -64,7 +64,7 @@ defmodule ExCypherTest do
           match(node(:rick, [], %{name: "Rick", role: "scientist"}))
         end
 
-      assert ~S[MATCH (rick {"name":"Rick","role":"scientist"})] == query
+      assert ~S[MATCH (rick {name:"Rick",role:"scientist"})] == query
     end
 
     test "with only props" do
@@ -73,7 +73,7 @@ defmodule ExCypherTest do
           match(node(%{name: "Rick", role: "scientist"}))
         end
 
-      assert ~S[MATCH ({"name":"Rick","role":"scientist"})] == query
+      assert ~S[MATCH ({name:"Rick",role:"scientist"})] == query
     end
   end
 
@@ -200,7 +200,7 @@ defmodule ExCypherTest do
     end
 
     test "accepts properties in relationships" do
-      expected = ~S[MATCH (a)-[:Rel {"name":"foo"}\]->(b)]
+      expected = ~S[MATCH (a)-[:Rel {name:"foo"}\]->(b)]
 
       query =
         cypher do
@@ -211,7 +211,7 @@ defmodule ExCypherTest do
     end
 
     test "accepts properties in named and labeled relationships" do
-      expected = ~S[MATCH (a)-[r:Rel {"name":"foo"}\]->(b)]
+      expected = ~S[MATCH (a)-[r:Rel {name:"foo"}\]->(b)]
 
       query =
         cypher do
@@ -339,7 +339,7 @@ defmodule ExCypherTest do
           create(node([:Node], %{name: "prop"}))
         end
 
-      assert ~S[CREATE (:Node {"name":"prop"})] = query
+      assert ~S[CREATE (:Node {name:"prop"})] = query
     end
 
     test "accepts multiple elements" do
@@ -368,7 +368,7 @@ defmodule ExCypherTest do
           merge(node([:Node], %{name: "prop"}))
         end
 
-      assert ~S[MERGE (:Node {"name":"prop"})] = query
+      assert ~S[MERGE (:Node {name:"prop"})] = query
     end
 
     test "accepts multiple elements" do

--- a/test/ex_cypher_test.exs
+++ b/test/ex_cypher_test.exs
@@ -354,7 +354,7 @@ defmodule ExCypherTest do
     test "accepts relationships" do
       query =
         cypher do
-          create((node(:a) -- rel([:R]) -> node(:b)))
+          create (node(:a) -- rel([:R]) -> node(:b))
         end
 
       assert "CREATE (a)-[:R]->(b)" = query


### PR DESCRIPTION
I've made the following changes:

* Removes quotes from generated queries - which was breaking the cypher language syntax;
* Applying good practices and improvements to documentation