### PR TITLE
Add support to maps

### DIFF
--- a/lib/ex_cypher.ex
+++ b/lib/ex_cypher.ex
@@ -148,15 +148,15 @@ defmodule ExCypher do
     Wraps contents of a Cypher query and returns the query string.
   """
   defmacro cypher(do: block) do
-    cypher_query(block)
+    cypher_query(block, __CALLER__)
   end
 
-  defp cypher_query(block) do
+  defp cypher_query(block, env) do
     {:ok, pid} = Buffer.new_query()
 
     Macro.postwalk(block, fn
       term = {command, _ctx, _args} when is_supported(command) ->
-        parse_term(pid, term)
+        parse_term(pid, term, env)
 
       term ->
         term
@@ -175,10 +175,10 @@ defmodule ExCypher do
     end
   end
 
-  defp parse_term(pid, term) do
+  defp parse_term(pid, term, env) do
     params =
       term
-      |> Clause.new()
+      |> Clause.new(env)
       |> Statement.parse()
 
     Buffer.put_buffer(pid, params)

--- a/lib/ex_cypher/clause.ex
+++ b/lib/ex_cypher/clause.ex
@@ -3,7 +3,7 @@ defmodule ExCypher.Clause do
   Abstraction on query clauses and their arguments
   """
 
-  defstruct [:name, :args]
+  defstruct [:name, :env, :args]
 
   alias __MODULE__
 
@@ -17,9 +17,12 @@ defmodule ExCypher.Clause do
   defguard is_supported(command_name)
            when command_name in @supported_statements
 
-  @spec new({name :: atom(), context :: list(), args :: term()}) :: Clause.t()
-  def new({name, _ctx, args}) when is_supported(name),
-    do: %Clause{name: name, args: args}
+  @spec new({name :: atom(), context :: list(), args :: term()},
+            env :: Macro.Env.t()) :: Clause.t()
+  def new(term, env \\ nil)
 
-  def new(term), do: %Clause{name: nil, args: term}
+  def new({name, _ctx, args}, env) when is_supported(name),
+    do: %Clause{name: name, env: env, args: args}
+
+  def new(term, env), do: %Clause{name: nil, env: env, args: term}
 end

--- a/lib/ex_cypher/clause.ex
+++ b/lib/ex_cypher/clause.ex
@@ -3,26 +3,8 @@ defmodule ExCypher.Clause do
   Abstraction on query clauses and their arguments
   """
 
-  defstruct [:name, :env, :args]
-
-  alias __MODULE__
-
-  @type t() :: %__MODULE__{
-          name: String.t(),
-          args: [term()]
-        }
-
   @supported_statements [:match, :create, :merge, :return, :where, :pipe_with, :order, :limit]
 
   defguard is_supported(command_name)
            when command_name in @supported_statements
-
-  @spec new({name :: atom(), context :: list(), args :: term()},
-            env :: Macro.Env.t()) :: Clause.t()
-  def new(term, env \\ nil)
-
-  def new({name, _ctx, args}, env) when is_supported(name),
-    do: %Clause{name: name, env: env, args: args}
-
-  def new(term, env), do: %Clause{name: nil, env: env, args: term}
 end

--- a/lib/ex_cypher/statement.ex
+++ b/lib/ex_cypher/statement.ex
@@ -19,15 +19,15 @@ defmodule ExCypher.Statement do
   @type command_name :: atom
 
   @spec parse(clause :: Clause.t()) :: String.t() | list()
-  def parse(%Clause{name: :where, args: ast}) do
-    ["WHERE", Where.parse(ast)]
+  def parse(%Clause{name: :where, args: ast, env: env}) do
+    ["WHERE", Where.parse(ast, env)]
   end
 
-  def parse(%Clause{name: :order, args: ast}) do
-    ["ORDER BY", Order.parse(ast)]
+  def parse(%Clause{name: :order, args: ast, env: env}) do
+    ["ORDER BY", Order.parse(ast, env)]
   end
 
-  def parse(%Clause{name: :pipe_with, args: ast}) do
+  def parse(%Clause{name: :pipe_with, args: ast, env: env}) do
     ["WITH", Generic.parse(ast)]
   end
 
@@ -37,6 +37,6 @@ defmodule ExCypher.Statement do
       |> Atom.to_string()
       |> String.upcase()
 
-    [command_name, Generic.parse(clause.args)]
+    [command_name, Generic.parse(clause.args, clause.env)]
   end
 end

--- a/lib/ex_cypher/statement.ex
+++ b/lib/ex_cypher/statement.ex
@@ -1,7 +1,6 @@
 defmodule ExCypher.Statement do
   @moduledoc false
 
-  alias ExCypher.Clause
   alias ExCypher.Statements.{Generic, Order, Where}
 
   # Cypher syntax varies depending on the statement being used. For example,
@@ -18,25 +17,26 @@ defmodule ExCypher.Statement do
 
   @type command_name :: atom
 
-  @spec parse(clause :: Clause.t()) :: String.t() | list()
-  def parse(%Clause{name: :where, args: ast, env: env}) do
+  @spec parse(cmd_name :: String.t(), ast :: term(), Macro.Env.t()) ::
+          String.t() | list()
+  def parse(:where, ast, env) do
     ["WHERE", Where.parse(ast, env)]
   end
 
-  def parse(%Clause{name: :order, args: ast, env: env}) do
+  def parse(:order, ast, env) do
     ["ORDER BY", Order.parse(ast, env)]
   end
 
-  def parse(%Clause{name: :pipe_with, args: ast, env: env}) do
-    ["WITH", Generic.parse(ast)]
+  def parse(:pipe_with, ast, env) do
+    ["WITH", Generic.parse(ast, env)]
   end
 
-  def parse(clause = %Clause{}) do
+  def parse(command_name, ast, env) do
     command_name =
-      clause.name
+      command_name
       |> Atom.to_string()
       |> String.upcase()
 
-    [command_name, Generic.parse(clause.args, clause.env)]
+    [command_name, Generic.parse(ast, env)]
   end
 end

--- a/lib/ex_cypher/statements/generic.ex
+++ b/lib/ex_cypher/statements/generic.ex
@@ -123,7 +123,7 @@ defmodule ExCypher.Statements.Generic do
       env
       |> Macro.Env.vars()
       |> Keyword.keys()
-      |> Enum.find(& &1 == var_name)
+      |> Enum.find(&(&1 == var_name))
     else
       false
     end

--- a/lib/ex_cypher/statements/order.ex
+++ b/lib/ex_cypher/statements/order.ex
@@ -7,7 +7,9 @@ defmodule ExCypher.Statements.Order do
   alias ExCypher.Statements.Generic
 
   @spec parse(ast :: term()) :: String.t()
-  def parse({term, ordering}) when ordering in [:asc, :desc] do
+  def parse(term, env \\ nil)
+
+  def parse({term, ordering}, _env) when ordering in [:asc, :desc] do
     direction =
       ordering
       |> Generic.parse()
@@ -16,11 +18,11 @@ defmodule ExCypher.Statements.Order do
     [Generic.parse(term), direction]
   end
 
-  def parse(list) when is_list(list) do
+  def parse(list, _env) when is_list(list) do
     list
     |> Enum.map(&parse/1)
     |> Enum.intersperse(",")
   end
 
-  def parse(ast), do: Generic.parse(ast)
+  def parse(ast, _env), do: Generic.parse(ast)
 end

--- a/lib/ex_cypher/statements/where.ex
+++ b/lib/ex_cypher/statements/where.ex
@@ -10,25 +10,27 @@ defmodule ExCypher.Statements.Where do
 
   @doc false
   @spec parse(ast :: term()) :: String.t()
-  def parse({:==, _, [first, nil | []]}),
+  def parse(term, env \\ nil)
+
+  def parse({:==, _, [first, nil | []]}, _env),
     do: [parse(first), "IS NULL"]
 
-  def parse({:!=, _, [first, nil | []]}),
+  def parse({:!=, _, [first, nil | []]}, _env),
     do: [parse(first), "IS NOT NULL"]
 
-  def parse({op, _, [first, last | []]})
+  def parse({op, _, [first, last | []]}, env)
       when op in @logical_operators do
     operator_name = fetch_operator(op)
 
-    [parse(first), operator_name, parse(last)]
+    [parse(first, env), operator_name, parse(last, env)]
   end
 
-  def parse(list) when is_list(list) do
-    Enum.map(list, &parse/1)
+  def parse(list, env) when is_list(list) do
+    Enum.map(list, &parse(&1, env))
   end
 
-  def parse(ast) do
-    Generic.parse(ast)
+  def parse(ast, env) do
+    Generic.parse(ast, env)
   end
 
   defp fetch_operator(operator) do

--- a/test/ex_cypher/clause_test.exs
+++ b/test/ex_cypher/clause_test.exs
@@ -4,20 +4,6 @@ defmodule ExCypher.ClauseTest do
   alias ExCypher.Clause
   require ExCypher.Clause
 
-  describe ".new/2" do
-    test "builds a new clause with given args" do
-      term = {:command_name, [], [arg1: 1, arg2: 2]}
-
-      assert %Clause{name: nil, args: ^term} = Clause.new(term)
-    end
-
-    test "splits the command name when its supported by framework" do
-      term = {name, _ctx, args} = {:match, [], [arg1: 1, arg2: 2]}
-
-      assert %Clause{name: ^name, args: ^args} = Clause.new(term)
-    end
-  end
-
   describe ".is_supported/1" do
     supported_terms = [:match, :create, :merge, :return, :where, :pipe_with, :order, :limit]
 

--- a/test/queries/create_test.exs
+++ b/test/queries/create_test.exs
@@ -113,7 +113,7 @@ defmodule Queries.CreateTest do
 
       query =
         cypher do
-          create node([:Person], %{name: person.name, age: person.age})
+          create(node([:Person], %{name: person.name, age: person.age}))
         end
 
       assert expected == query

--- a/test/queries/create_test.exs
+++ b/test/queries/create_test.exs
@@ -106,5 +106,17 @@ defmodule Queries.CreateTest do
 
       assert expected == query
     end
+
+    test "with maps" do
+      person = %{name: "bob", age: 12}
+      expected = ~s[CREATE (:Person {age:#{person.age},name:\"#{person.name}\"})]
+
+      query =
+        cypher do
+          create node([:Person], %{name: person.name, age: person.age})
+        end
+
+      assert expected == query
+    end
   end
 end

--- a/test/queries/match_test.exs
+++ b/test/queries/match_test.exs
@@ -302,7 +302,7 @@ defmodule Queries.MatchTest do
 
       query =
         cypher do
-          match node([:Person], %{name: person.name, age: person.age})
+          match(node([:Person], %{name: person.name, age: person.age}))
         end
 
       assert expected == query

--- a/test/queries/match_test.exs
+++ b/test/queries/match_test.exs
@@ -295,5 +295,17 @@ defmodule Queries.MatchTest do
 
       assert expected == query
     end
+
+    test "with maps" do
+      person = %{name: "bob", age: 12}
+      expected = ~s[MATCH (:Person {age:#{person.age},name:\"#{person.name}\"})]
+
+      query =
+        cypher do
+          match node([:Person], %{name: person.name, age: person.age})
+        end
+
+      assert expected == query
+    end
   end
 end

--- a/test/queries/merge_test.exs
+++ b/test/queries/merge_test.exs
@@ -106,5 +106,17 @@ defmodule Queries.MergeTest do
 
       assert expected == query
     end
+
+    test "with maps" do
+      person = %{name: "bob", age: 12}
+      expected = ~s[MERGE (:Person {age:#{person.age},name:\"#{person.name}\"})]
+
+      query =
+        cypher do
+          merge node([:Person], %{name: person.name, age: person.age})
+        end
+
+      assert expected == query
+    end
   end
 end

--- a/test/queries/merge_test.exs
+++ b/test/queries/merge_test.exs
@@ -113,7 +113,7 @@ defmodule Queries.MergeTest do
 
       query =
         cypher do
-          merge node([:Person], %{name: person.name, age: person.age})
+          merge(node([:Person], %{name: person.name, age: person.age}))
         end
 
       assert expected == query

--- a/test/queries/where_test.exs
+++ b/test/queries/where_test.exs
@@ -150,5 +150,18 @@ defmodule Queries.WhereTest do
 
       assert expected == query
     end
+
+    test "can use it with maps" do
+      person = %{name: "bob", age: 12}
+      expected = ~s[MATCH (:Person) WHERE p.name = \"#{person.name}\" AND p.age = #{person.age}]
+
+      query =
+        cypher do
+          match node([:Person])
+          where p.name == person.name and p.age == person.age
+        end
+
+      assert expected == query
+    end
   end
 end

--- a/test/queries/where_test.exs
+++ b/test/queries/where_test.exs
@@ -157,8 +157,8 @@ defmodule Queries.WhereTest do
 
       query =
         cypher do
-          match node([:Person])
-          where p.name == person.name and p.age == person.age
+          match(node([:Person]))
+          where(p.name == person.name and p.age == person.age)
         end
 
       assert expected == query


### PR DESCRIPTION
### What changed?

1. Added support to using maps inside `WHERE` statements. The old version was parsing every AST node using the dot operator into a string. Now, it attempts to resolve the variable whenever is possible.
2. Removed the clause dependency from the parsing logic, since it was adding an unnecessary complexity to the code.
3. Fixes #16 