### PR TITLE
Allow aliasing in WITH clauses

### DIFF
--- a/lib/ex_cypher/statement.ex
+++ b/lib/ex_cypher/statement.ex
@@ -1,7 +1,7 @@
 defmodule ExCypher.Statement do
   @moduledoc false
 
-  alias ExCypher.Statements.{Generic, Order, Where}
+  alias ExCypher.Statements.{Generic, Order, Where, With}
 
   # Cypher syntax varies depending on the statement being used. For example,
   # the `WHERE` statement's syntax can vary a lot when compared to simpler
@@ -28,7 +28,7 @@ defmodule ExCypher.Statement do
   end
 
   def parse(:pipe_with, ast, env) do
-    ["WITH", Generic.parse(ast, env)]
+    ["WITH", With.parse(ast, env)]
   end
 
   def parse(command_name, ast, env) do

--- a/lib/ex_cypher/statements/with.ex
+++ b/lib/ex_cypher/statements/with.ex
@@ -1,0 +1,23 @@
+defmodule ExCypher.Statements.With do
+  @moduledoc false
+
+  # Parses WITH statements
+
+  alias ExCypher.Statements.Generic
+
+  @doc false
+  # Parses aliasing
+  def parse({term, [as: bind]}, env) do
+    [parse(term, env), "AS", Atom.to_string(bind)]
+  end
+
+  def parse(list, env) when is_list(list) do
+    list
+    |> Enum.map(&parse(&1, env))
+    |> Enum.intersperse(",")
+  end
+
+  def parse(ast, env) do
+    Generic.parse(ast, env)
+  end
+end

--- a/test/queries/with_test.exs
+++ b/test/queries/with_test.exs
@@ -33,5 +33,35 @@ defmodule Queries.WithTest do
 
       assert "MATCH (n) WITH rand(), n" = query
     end
+
+    test "with aliasing" do
+      query =
+        cypher do
+          match(node(:n))
+          pipe_with({:n, as: :p})
+        end
+
+      assert "MATCH (n) WITH n AS p" = query
+    end
+
+    test "with mixed list of aliased and non-aliased variables" do
+      query =
+        cypher do
+          match(node(:n), node(:c))
+          pipe_with({:n, as: :p}, :c)
+        end
+
+      assert "MATCH (n), (c) WITH n AS p, c" = query
+    end
+
+    test "with mixed list of aliased variables and fragments" do
+      query =
+        cypher do
+          match(node(:n))
+          pipe_with({fragment("rand()"), as: :r}, :n)
+        end
+
+      assert "MATCH (n) WITH rand() AS r, n" = query
+    end
   end
 end


### PR DESCRIPTION
### What changed?

* Added support to aliased variables in `WITH` statements using a keyword syntax:

```elixir
        cypher do
          match(node(:n))
          pipe_with({:n, as: :p})
        end
```

* Fixes #22 