### PR TITLE
Support SET statements

### DIFF
--- a/lib/ex_cypher/clause.ex
+++ b/lib/ex_cypher/clause.ex
@@ -3,7 +3,7 @@ defmodule ExCypher.Clause do
   Abstraction on query clauses and their arguments
   """
 
-  @supported_statements [:match, :create, :merge, :return, :where, :pipe_with, :order, :limit]
+  @supported_statements [:match, :create, :merge, :return, :where, :pipe_with, :order, :limit, :set]
 
   defguard is_supported(command_name)
            when command_name in @supported_statements

--- a/lib/ex_cypher/graph/component.ex
+++ b/lib/ex_cypher/graph/component.ex
@@ -12,12 +12,28 @@ defmodule ExCypher.Graph.Component do
   # This module provides a way to help converting those contents
   # into a cypher-compliant strings that can be used to build
   # both nodes and relationships arguments.
-  def escape_node(node_name \\ "", node_labels \\ [], node_props \\ %{}) do
+  def escape_node(node_name \\ "", node_labels \\ [], node_props \\ %{})
+
+  def escape_node(node_name, node_labels, props) when props == %{} do
+    [escape(node_name), escape(node_labels)]
+  end
+
+  def escape_node(node_name, node_labels, node_props) do
     [escape(node_name), escape(node_labels), escape(node_props)]
   end
 
-  def escape_relation(rel_name \\ "", rel_labels \\ [], rel_props \\ %{}) do
+  def escape_relation(rel_name \\ "", rel_labels \\ [], rel_props \\ %{})
+
+  def escape_relation(rel_name, rel_labels, props) when props == %{} do
+    [escape(rel_name), escape(rel_labels)]
+  end
+
+  def escape_relation(rel_name, rel_labels, rel_props) do
     [escape(rel_name), escape(rel_labels), escape(rel_props)]
+  end
+
+  def escape_properties(props = %{}) do
+    [escape(props)]
   end
 
   def escape(nil), do: ""
@@ -27,8 +43,6 @@ defmodule ExCypher.Graph.Component do
       do: Atom.to_string(element)
 
   def escape([]), do: ""
-
-  def escape(props) when props == %{}, do: ""
 
   def escape(list)
       when is_list(list),

--- a/lib/ex_cypher/graph/node.ex
+++ b/lib/ex_cypher/graph/node.ex
@@ -38,6 +38,17 @@ defmodule ExCypher.Graph.Node do
   @spec node(props :: map()) :: String.t()
   def node(props = %{}), do: node(nil, nil, props)
 
+  @spec node(node_name :: Strint.t() | atom(),
+             props :: map()) :: String.t()
+  def node(node_name, props = %{})
+      when is_binary(node_name) or is_atom(node_name),
+      do: node(node_name, [], props)
+
+  @spec node(labels_list :: [atom()], props :: map()) :: String.t()
+  def node(labels_list, props = %{})
+      when is_list(labels_list),
+      do: node("", labels_list, props)
+
   @spec node(
           name :: String.t(),
           labels :: list(),

--- a/lib/ex_cypher/graph/relationship.ex
+++ b/lib/ex_cypher/graph/relationship.ex
@@ -43,6 +43,11 @@ defmodule ExCypher.Graph.Relationship do
       when is_list(labels),
       do: rel("", labels, props)
 
+  @spec rel(rel_name :: String.t() | atom(), props :: map()) :: String.t()
+  def rel(rel_name, props = %{})
+      when is_binary(rel_name) or is_atom(rel_name),
+      do: rel(rel_name, [], props)
+
   @spec rel(
           name :: String.t(),
           labels :: list(),

--- a/lib/ex_cypher/statement.ex
+++ b/lib/ex_cypher/statement.ex
@@ -1,7 +1,7 @@
 defmodule ExCypher.Statement do
   @moduledoc false
 
-  alias ExCypher.Statements.{Generic, Order, Where}
+  alias ExCypher.Statements.{Generic, Order, Set, Where}
 
   # Cypher syntax varies depending on the statement being used. For example,
   # the `WHERE` statement's syntax can vary a lot when compared to simpler
@@ -29,6 +29,10 @@ defmodule ExCypher.Statement do
 
   def parse(:pipe_with, ast, env) do
     ["WITH", Generic.parse(ast, env)]
+  end
+
+  def parse(:set, ast, env) do
+    ["SET", Set.parse(ast, env)]
   end
 
   def parse(command_name, ast, env) do

--- a/lib/ex_cypher/statements/generic.ex
+++ b/lib/ex_cypher/statements/generic.ex
@@ -76,6 +76,8 @@ defmodule ExCypher.Statements.Generic do
     apply(Relationship, :assoc, [association, {from, to}])
   end
 
+  def parse(nil, _env), do: "NULL"
+
   def parse(term, _env) when is_atom(term),
     do: Atom.to_string(term)
 

--- a/lib/ex_cypher/statements/set.ex
+++ b/lib/ex_cypher/statements/set.ex
@@ -8,7 +8,7 @@ defmodule ExCypher.Statements.Set do
     [parse(first, env), "=", parse(last, env)]
   end
 
-  def parse({:%{}, _ctx, args}, env) do
+  def parse({:%{}, _ctx, args}, _env) do
     properties =
       args
       |> Enum.into(%{})
@@ -16,6 +16,17 @@ defmodule ExCypher.Statements.Set do
 
     quote do
       unquote(properties)
+      |> List.flatten()
+      |> Enum.join()
+      |> String.trim()
+    end
+  end
+
+  def parse({:label, _ctx, [node_name, labels | []]}, env) do
+    statement = [parse(node_name, env), ":", Enum.intersperse(labels, ":")]
+
+    quote do
+      unquote(statement)
       |> List.flatten()
       |> Enum.join()
       |> String.trim()

--- a/lib/ex_cypher/statements/set.ex
+++ b/lib/ex_cypher/statements/set.ex
@@ -8,18 +8,12 @@ defmodule ExCypher.Statements.Set do
     [parse(first, env), "=", parse(last, env)]
   end
 
-  def parse({:%{}, _ctx, args}, _env) do
-    properties =
-      args
-      |> Enum.into(%{})
-      |> Component.escape_properties()
+  def parse({:%{}, _, [{:|, _, [node_name, args | []]}]}, env) do
+    [parse(node_name, env), "+=", parse_properties(args)]
+  end
 
-    quote do
-      unquote(properties)
-      |> List.flatten()
-      |> Enum.join()
-      |> String.trim()
-    end
+  def parse({:%{}, _ctx, args}, _env) do
+    parse_properties(args)
   end
 
   def parse({:label, _ctx, [node_name, labels | []]}, env) do
@@ -44,5 +38,20 @@ defmodule ExCypher.Statements.Set do
 
   def parse(ast, env) do
     Generic.parse(ast, env)
+  end
+
+  defp parse_properties(props) do
+    properties =
+      props
+      |> IO.inspect()
+      |> Enum.into(%{})
+      |> Component.escape_properties()
+
+    quote do
+      unquote(properties)
+      |> List.flatten()
+      |> Enum.join()
+      |> String.trim()
+    end
   end
 end

--- a/lib/ex_cypher/statements/set.ex
+++ b/lib/ex_cypher/statements/set.ex
@@ -2,9 +2,24 @@ defmodule ExCypher.Statements.Set do
   @moduledoc false
 
   alias ExCypher.Statements.Generic
+  alias ExCypher.Graph.Component
 
   def parse({:=, _ctx, [first, last |[]]}, env) do
     [parse(first, env), "=", parse(last, env)]
+  end
+
+  def parse({:%{}, _ctx, args}, env) do
+    properties =
+      args
+      |> Enum.into(%{})
+      |> Component.escape_properties()
+
+    quote do
+      unquote(properties)
+      |> List.flatten()
+      |> Enum.join()
+      |> String.trim()
+    end
   end
 
   def parse({atom, _ctx, nil}, _env) when is_atom(atom), do:

--- a/lib/ex_cypher/statements/set.ex
+++ b/lib/ex_cypher/statements/set.ex
@@ -26,7 +26,9 @@ defmodule ExCypher.Statements.Set do
     Atom.to_string(atom)
 
   def parse(list, env) when is_list(list) do
-    Enum.map(list, &parse(&1, env))
+    list
+    |> Enum.map(&parse(&1, env))
+    |> Enum.intersperse(",")
   end
 
   def parse(ast, env) do

--- a/lib/ex_cypher/statements/set.ex
+++ b/lib/ex_cypher/statements/set.ex
@@ -1,0 +1,20 @@
+defmodule ExCypher.Statements.Set do
+  @moduledoc false
+
+  alias ExCypher.Statements.Generic
+
+  def parse({:=, _ctx, [first, last |[]]}, env) do
+    [parse(first, env), "=", parse(last, env)]
+  end
+
+  def parse({atom, _ctx, nil}, _env) when is_atom(atom), do:
+    Atom.to_string(atom)
+
+  def parse(list, env) when is_list(list) do
+    Enum.map(list, &parse(&1, env))
+  end
+
+  def parse(ast, env) do
+    Generic.parse(ast, env)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ExCypher.MixProject do
     [
       app: :ex_cypher,
       description: "A DSL to interact with cypher query language",
-      version: "0.2.0",
+      version: "0.3.0-rc.1",
       elixir: "~> 1.9",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/queries/set_test.exs
+++ b/test/queries/set_test.exs
@@ -20,12 +20,69 @@ defmodule Queries.SetTest do
     test "allows updating a single property to NULL" do
       query = cypher do
         match(node(:p, [:Person], %{name: "Andy"}))
-        set p = nil
+        set p.name = nil
         return p.name
       end
 
       expected = "MATCH (p:Person {name:\"Andy\"}) " <> \
-                 "SET p = NULL " <> \
+                 "SET p.name = NULL " <> \
+                 "RETURN p.name"
+
+      assert ^expected = query
+    end
+
+    test "allows fragments inside queries" do
+      query = cypher do
+        match(node(:p, [:Person], %{name: "Andy"}))
+        set p.age = fragment("toString(p.age)")
+        return p.name
+      end
+
+      expected = "MATCH (p:Person {name:\"Andy\"}) " <> \
+                 "SET p.age = toString(p.age) " <> \
+                 "RETURN p.name"
+
+      assert ^expected = query
+    end
+
+    test "allows copying attributes from other nodes" do
+      query = cypher do
+        match(node(:p1, [:Person], %{name: "Andy"}),
+              node(:p2, [:Person], %{name: "Bob"}))
+        set p1 = p2
+        return p.name
+      end
+
+      expected = "MATCH (p1:Person {name:\"Andy\"}), (p2:Person {name:\"Bob\"}) " <> \
+                 "SET p1 = p2 " <> \
+                 "RETURN p.name"
+
+      assert ^expected = query
+    end
+
+    test "allows using a map to set multiple properties at once" do
+      query = cypher do
+        match(node(:p, [:Person], %{name: "Andy"}))
+        set p = %{name: "Bob", age: 35}
+        return p.name
+      end
+
+      expected = "MATCH (p:Person {name:\"Andy\"}) " <> \
+                 "SET p = {age:35,name:\"Bob\"} " <> \
+                 "RETURN p.name"
+
+      assert ^expected = query
+    end
+
+    test "allows removing all properties with an empty map" do
+      query = cypher do
+        match(node(:p, [:Person], %{name: "Andy"}))
+        set p = %{}
+        return p.name
+      end
+
+      expected = "MATCH (p:Person {name:\"Andy\"}) " <> \
+                 "SET p = {} " <> \
                  "RETURN p.name"
 
       assert ^expected = query

--- a/test/queries/set_test.exs
+++ b/test/queries/set_test.exs
@@ -1,0 +1,34 @@
+defmodule Queries.SetTest do
+  use ExUnit.Case
+  import ExCypher
+
+  describe "SET" do
+    test "allows updating a single property" do
+      query = cypher do
+        match(node(:p, [:Person], %{name: "Andy"}))
+        set p.name = "Bob"
+        return p.name
+      end
+
+      expected = "MATCH (p:Person {name:\"Andy\"}) " <> \
+                 "SET p.name = \"Bob\" " <> \
+                 "RETURN p.name"
+
+      assert ^expected = query
+    end
+
+    test "allows updating a single property to NULL" do
+      query = cypher do
+        match(node(:p, [:Person], %{name: "Andy"}))
+        set p = nil
+        return p.name
+      end
+
+      expected = "MATCH (p:Person {name:\"Andy\"}) " <> \
+                 "SET p = NULL " <> \
+                 "RETURN p.name"
+
+      assert ^expected = query
+    end
+  end
+end

--- a/test/queries/set_test.exs
+++ b/test/queries/set_test.exs
@@ -101,5 +101,33 @@ defmodule Queries.SetTest do
 
       assert ^expected = query
     end
+
+    test "allows setting a new label to a node" do
+      query = cypher do
+        match(node(:p, [:Person], %{name: "Andy"}))
+        set label(:p, [:Teacher])
+        return p.name
+      end
+
+      expected = "MATCH (p:Person {name:\"Andy\"}) " <> \
+                 "SET p:Teacher " <> \
+                 "RETURN p.name"
+
+      assert ^expected = query
+    end
+
+    test "allows setting multiple labels to a node" do
+      query = cypher do
+        match(node(:p, [:Person], %{name: "Andy"}))
+        set label(:p, [:Teacher, :Scientist])
+        return p.name
+      end
+
+      expected = "MATCH (p:Person {name:\"Andy\"}) " <> \
+                 "SET p:Teacher:Scientist " <> \
+                 "RETURN p.name"
+
+      assert ^expected = query
+    end
   end
 end

--- a/test/queries/set_test.exs
+++ b/test/queries/set_test.exs
@@ -87,5 +87,19 @@ defmodule Queries.SetTest do
 
       assert ^expected = query
     end
+
+    test "allows multiple properties using a comma separator" do
+      query = cypher do
+        match(node(:p, [:Person], %{name: "Andy"}))
+        set p.name = "bob", p.age = 23
+        return p.name
+      end
+
+      expected = "MATCH (p:Person {name:\"Andy\"}) " <> \
+                 "SET p.name = \"bob\", p.age = 23 " <> \
+                 "RETURN p.name"
+
+      assert ^expected = query
+    end
   end
 end

--- a/test/queries/set_test.exs
+++ b/test/queries/set_test.exs
@@ -129,5 +129,19 @@ defmodule Queries.SetTest do
 
       assert ^expected = query
     end
+
+    test "allows updating specific properties" do
+      query = cypher do
+        match(node(:p, [:Person], %{name: "Andy"}))
+        set %{p | age: 35}
+        return p.name
+      end
+
+      expected = "MATCH (p:Person {name:\"Andy\"}) " <> \
+                 "SET p += {age:35} " <> \
+                 "RETURN p.name"
+
+      assert ^expected = query
+    end
   end
 end


### PR DESCRIPTION
I'm adding support to SET statements now. The full documentation can be checked at https://neo4j.com/docs/cypher-manual/current/clauses/set/

### Main objectives

- [x] Allow SET properties to `NULL`;
- [x] Allow SET properties to basic types (integers, strings, ...);
- [x] Allow SET multiple properties using a map;
- [x] Allow copying properties between nodes;
- [x] Allow SET to remove a node's properties using a blank map;
- [x] Allow SET to incrementally add properties using `+=` operator;
- [x] Allow SET multiple properties using a comma separator;
- [x] Allow SET a single label to a node
- [x] Allow SET multiple labels to a node  