### PR TITLE
Multiple labels

### DIFF
--- a/lib/ex_cypher/graph/component.ex
+++ b/lib/ex_cypher/graph/component.ex
@@ -46,7 +46,7 @@ defmodule ExCypher.Graph.Component do
 
   def escape(list)
       when is_list(list),
-      do: [":" | Enum.intersperse(list, ",")]
+      do: [":" | Enum.intersperse(list, ":")]
 
   def escape(props = %{}) do
     args =

--- a/test/integration/creating_nodes_test.exs
+++ b/test/integration/creating_nodes_test.exs
@@ -38,9 +38,9 @@ defmodule Integration.CreatingNodesTest do
         end
 
       assert %{
-        records: [],
-        stats: %{"nodes-created" => 3}
-      } = Server.query(query)
+               records: [],
+               stats: %{"nodes-created" => 3}
+             } = Server.query(query)
     end
 
     test "is able to build associations" do
@@ -68,9 +68,9 @@ defmodule Integration.CreatingNodesTest do
         end
 
       assert %{
-        records: [["Anne"], ["Jack"]],
-        stats: %{"relationships-created" => 2}
-      } = Server.query(query)
+               records: [["Anne"], ["Jack"]],
+               stats: %{"relationships-created" => 2}
+             } = Server.query(query)
     end
 
     test "is able to merge nodes and relationships" do
@@ -97,37 +97,40 @@ defmodule Integration.CreatingNodesTest do
           merge((node(:anne) -- rel([:WORKS_WITH]) -> node(:jack)))
         end
 
-      assert %{stats: %{"nodes-created" => 1, "relationships-created" => 2}} =
-        Server.query(query)
+      assert %{stats: %{"nodes-created" => 1, "relationships-created" => 2}} = Server.query(query)
     end
 
     test "is able to create nodes with multiple labels" do
       query =
         cypher do
-          create(
-            node(:person, [:Person, :Inventor, :Artist], %{name: "Leonardo da Vinci"})
-          )
+          create(node(:person, [:Person, :Inventor, :Artist], %{name: "Leonardo da Vinci"}))
         end
 
       assert %{stats: %{"nodes-created" => 1}} = Server.query(query)
 
       assert %{records: [["Leonardo da Vinci"]]} =
-        Server.query(cypher do
-          match(node(:person, [:Inventor]))
-          return person.name
-        end)
+               Server.query(
+                 cypher do
+                   match(node(:person, [:Inventor]))
+                   return(person.name)
+                 end
+               )
 
       assert %{records: [["Leonardo da Vinci"]]} =
-        Server.query(cypher do
-          match(node(:person, [:Person]))
-          return person.name
-        end)
+               Server.query(
+                 cypher do
+                   match(node(:person, [:Person]))
+                   return(person.name)
+                 end
+               )
 
       assert %{records: [["Leonardo da Vinci"]]} =
-        Server.query(cypher do
-          match(node(:person, [:Artist, :Inventor]))
-          return person.name
-        end)
+               Server.query(
+                 cypher do
+                   match(node(:person, [:Artist, :Inventor]))
+                   return(person.name)
+                 end
+               )
+    end
   end
-end
 end

--- a/test/integration/creating_nodes_test.exs
+++ b/test/integration/creating_nodes_test.exs
@@ -1,138 +1,133 @@
 defmodule Integration.CreatingNodesTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
 
   import ExCypher
   alias ExCypher.Support.Server
 
-  setup do
+  setup_all do
     Server.start_link()
+  end
+
+  setup do
+    Server.query("MATCH (n) DETACH DELETE n")
+    :ok
   end
 
   @moduletag integration: true
 
   describe "querying stuff in neo4j" do
     test "is able to insert new nodes with CREATE statements" do
-      Server.transaction(fn conn ->
-        query =
-          cypher do
-            create(node(:p, [:Person], %{name: "Anne"}))
-            return(p.name)
-            order({p.name, :asc})
-          end
+      query =
+        cypher do
+          create(node(:p, [:Person], %{name: "Anne"}))
+          return(p.name)
+          order({p.name, :asc})
+        end
 
-        assert %{records: [["Anne"]]} = Server.query(conn, query)
-      end)
+      assert %{records: [["Anne"]]} = Server.query(query)
     end
 
     test "is able to insert multiple nodes" do
-      Server.transaction(fn conn ->
-        query =
-          cypher do
-            create(
-              node([:Person], %{name: "Anne"}),
-              node([:Person], %{name: "Bob"}),
-              node([:Robot], %{name: "WALL-E"})
-            )
-          end
+      query =
+        cypher do
+          create(
+            node([:Person], %{name: "Anne"}),
+            node([:Person], %{name: "Bob"}),
+            node([:Robot], %{name: "WALL-E"})
+          )
+        end
 
-        assert %{
-                 records: [],
-                 stats: %{"nodes-created" => 3}
-               } = Server.query(conn, query)
-      end)
+      assert %{
+        records: [],
+        stats: %{"nodes-created" => 3}
+      } = Server.query(query)
     end
 
     test "is able to build associations" do
-      Server.transaction(fn conn ->
-        query =
-          cypher do
-            create(
-              node(:acme, [:Company], %{name: "Acme"}),
-              node(:anne, [:Person], %{name: "Anne"}),
-              node(:jack, [:Person], %{name: "Jack"})
-            )
-          end
+      query =
+        cypher do
+          create(
+            node(:acme, [:Company], %{name: "Acme"}),
+            node(:anne, [:Person], %{name: "Anne"}),
+            node(:jack, [:Person], %{name: "Jack"})
+          )
+        end
 
-        assert %{stats: %{"nodes-created" => 3}} = Server.query(conn, query)
+      assert %{stats: %{"nodes-created" => 3}} = Server.query(query)
 
-        query =
-          cypher do
-            match(
-              node(:company, [:Company], %{name: "Acme"}),
-              node(:person, [:Person])
-            )
+      query =
+        cypher do
+          match(
+            node(:company, [:Company], %{name: "Acme"}),
+            node(:person, [:Person])
+          )
 
-            create((node(:person) -- rel([:WORKS_IN]) -> node(:company)))
-            return(person.name)
-            order({person.name, :asc})
-          end
+          create((node(:person) -- rel([:WORKS_IN]) -> node(:company)))
+          return(person.name)
+          order({person.name, :asc})
+        end
 
-        assert %{
-                 records: [["Anne"], ["Jack"]],
-                 stats: %{"relationships-created" => 2}
-               } = Server.query(conn, query)
-      end)
+      assert %{
+        records: [["Anne"], ["Jack"]],
+        stats: %{"relationships-created" => 2}
+      } = Server.query(query)
     end
 
     test "is able to merge nodes and relationships" do
-      Server.transaction(fn conn ->
-        query =
-          cypher do
-            create(
-              node(:acme, [:Company], %{name: "Acme"}),
-              node(:anne, [:Person], %{name: "Anne"}),
-              node(:jack, [:Person], %{name: "Jack"}),
-              (node(:anne) -- rel([:WORKS_IN]) -> node(:acme))
-            )
-          end
+      query =
+        cypher do
+          create(
+            node(:acme, [:Company], %{name: "Acme"}),
+            node(:anne, [:Person], %{name: "Anne"}),
+            node(:jack, [:Person], %{name: "Jack"}),
+            (node(:anne) -- rel([:WORKS_IN]) -> node(:acme))
+          )
+        end
 
-        assert %{stats: %{"nodes-created" => 3}} = Server.query(conn, query)
+      assert %{stats: %{"nodes-created" => 3}} = Server.query(query)
 
-        query =
-          cypher do
-            merge(node(:acme, [:Company], %{name: "Acme"}))
-            merge(node(:anne, [:Person], %{name: "Anne"}))
-            merge(node(:jack, [:Person], %{name: "Jack"}))
-            merge(node(:bob, [:Person], %{name: "Bob"}))
-            merge((node(:anne) -- rel([:WORKS_IN]) -> node(:acme)))
-            merge((node(:jack) -- rel([:WORKS_IN]) -> node(:acme)))
-            merge((node(:anne) -- rel([:WORKS_WITH]) -> node(:jack)))
-          end
+      query =
+        cypher do
+          merge(node(:acme, [:Company], %{name: "Acme"}))
+          merge(node(:anne, [:Person], %{name: "Anne"}))
+          merge(node(:jack, [:Person], %{name: "Jack"}))
+          merge(node(:bob, [:Person], %{name: "Bob"}))
+          merge((node(:anne) -- rel([:WORKS_IN]) -> node(:acme)))
+          merge((node(:jack) -- rel([:WORKS_IN]) -> node(:acme)))
+          merge((node(:anne) -- rel([:WORKS_WITH]) -> node(:jack)))
+        end
 
-        assert %{stats: %{"nodes-created" => 1, "relationships-created" => 2}} =
-                 Server.query(conn, query)
-      end)
+      assert %{stats: %{"nodes-created" => 1, "relationships-created" => 2}} =
+        Server.query(query)
     end
 
     test "is able to create nodes with multiple labels" do
-      Server.transaction(fn conn ->
-        query =
-          cypher do
-            create(
-              node(:person, [:Person, :Inventor, :Artist], %{name: "Leonardo da Vinci"})
-            )
-          end
+      query =
+        cypher do
+          create(
+            node(:person, [:Person, :Inventor, :Artist], %{name: "Leonardo da Vinci"})
+          )
+        end
 
-        assert %{stats: %{"nodes-created" => 1}} = Server.query(conn, query)
+      assert %{stats: %{"nodes-created" => 1}} = Server.query(query)
 
-        assert %{records: [["Leonardo da Vinci"]]} =
-          Server.query(conn, cypher do
-            match(node(:person, [:Inventor]))
-            return person.name
-          end)
+      assert %{records: [["Leonardo da Vinci"]]} =
+        Server.query(cypher do
+          match(node(:person, [:Inventor]))
+          return person.name
+        end)
 
-        assert %{records: [["Leonardo da Vinci"]]} =
-          Server.query(conn, cypher do
-            match(node(:person, [:Person]))
-            return person.name
-          end)
+      assert %{records: [["Leonardo da Vinci"]]} =
+        Server.query(cypher do
+          match(node(:person, [:Person]))
+          return person.name
+        end)
 
-        assert %{records: [["Leonardo da Vinci"]]} =
-          Server.query(conn, cypher do
-            match(node(:person, [:Artist, :Inventor]))
-            return person.name
-          end)
-      end)
-    end
+      assert %{records: [["Leonardo da Vinci"]]} =
+        Server.query(cypher do
+          match(node(:person, [:Artist, :Inventor]))
+          return person.name
+        end)
   end
+end
 end

--- a/test/integration/querying_test.exs
+++ b/test/integration/querying_test.exs
@@ -4,9 +4,8 @@ defmodule Integration.QueryingTest do
   import ExCypher
   alias ExCypher.Support.Server
 
-  setup_all do
+  setup do
     Server.start_link()
-    :ok
   end
 
   @moduletag integration: true

--- a/test/integration/querying_test.exs
+++ b/test/integration/querying_test.exs
@@ -1,37 +1,40 @@
 defmodule Integration.QueryingTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
 
   import ExCypher
   alias ExCypher.Support.Server
 
-  setup do
+  setup_all do
     Server.start_link()
+  end
+
+  setup do
+    Server.query("MATCH (n) DETACH DELETE n")
+    :ok
   end
 
   @moduletag integration: true
 
   describe "querying stuff in neo4j" do
     test "is able to fetch nodes using MATCH queries" do
-      Server.transaction(fn conn ->
-        Server.query(conn, """
+      Server.query("""
           CREATE (:Person {name:"Bob"}), (:Person {name:"Ellie"}),
                  (:Person {name:"Mark"}), (:Person {name:"Jane"})
         """)
 
-        query =
-          cypher do
-            match(node(:p, [:Person]))
-            return(p.name)
-            order({p.name, :asc})
-          end
+      query =
+        cypher do
+          match(node(:p, [:Person]))
+          return(p.name)
+          order({p.name, :asc})
+        end
 
-        assert %{records: [["Bob"], ["Ellie"], ["Jane"], ["Mark"]]} = Server.query(conn, query)
-      end)
+      assert %{records: [["Bob"], ["Ellie"], ["Jane"], ["Mark"]]} =
+        Server.query(query)
     end
 
     test "is able to filter nodes" do
-      Server.transaction(fn conn ->
-        Server.query(conn, """
+      Server.query("""
           CREATE (:Person {name:"Bob", age:42}),
                  (:Person {name:"Peter", age:35}),
                  (:Person {name:"Lucy", age:35}),
@@ -39,66 +42,60 @@ defmodule Integration.QueryingTest do
                  (:Person {name:"Mary", age:25})
         """)
 
-        query =
-          cypher do
-            match(node(:p, [:Person]))
-            where(p.age >= 25)
-            return(p.name)
-            order({p.age, :asc}, {p.name, :asc})
-            limit(3)
-          end
+      query =
+        cypher do
+          match(node(:p, [:Person]))
+          where(p.age >= 25)
+          return(p.name)
+          order({p.age, :asc}, {p.name, :asc})
+          limit(3)
+        end
 
-        assert %{records: [["Mary"], ["Lucy"], ["Peter"]]} = Server.query(conn, query)
-      end)
+      assert %{records: [["Mary"], ["Lucy"], ["Peter"]]} = Server.query(query)
     end
 
     test "is able to filter required nodes with different labels" do
-      Server.transaction(fn conn ->
-        Server.query(conn, """
+      Server.query("""
           CREATE (:Droid {name:"R2-D2"}),
                  (:Droid {name:"C3PO"}),
                  (:Cyborg {name:"Arnold"})
         """)
 
-        query =
-          cypher do
-            match(node(:d, [:Droid]))
-            return(d.name)
-            order({d.name, :asc})
-          end
+      query =
+        cypher do
+          match(node(:d, [:Droid]))
+          return(d.name)
+          order({d.name, :asc})
+        end
 
-        assert %{records: [["C3PO"], ["R2-D2"]]} = Server.query(conn, query)
-      end)
+      assert %{records: [["C3PO"], ["R2-D2"]]} = Server.query(query)
     end
 
     test "is able to match associations" do
-      Server.transaction(fn conn ->
-        Server.query(conn, """
+      Server.query("""
           CREATE (acme:Company {name: "Acme"}),
                  (marvel:Company {name: "Marvel"}),
                  (martin:Person {name:"Martin"})-[:WORKS_IN]->(acme),
                  (anne:Person {name:"Anne"})-[:WORKS_IN]->(acme),
                  (hiro:Person {name:"Hiro"})-[:WORKS_IN]->(marvel),
                  (charles:Person {name:"Charles"})-[:WORKS_IN]->(acme)
-        """)
+          """)
 
-        query =
-          cypher do
-            match(
-              (node(:person, [:Person]) -- rel([:WORKS_IN]) -> node([:Company], %{name: "Acme"}))
-            )
+      query =
+        cypher do
+          match(
+            (node(:person, [:Person]) -- rel([:WORKS_IN]) -> node([:Company], %{name: "Acme"}))
+          )
 
-            return(person.name)
-            order({person.name, :asc})
-          end
+          return(person.name)
+          order({person.name, :asc})
+        end
 
-        assert %{records: [["Anne"], ["Charles"], ["Martin"]]} = Server.query(conn, query)
-      end)
+      assert %{records: [["Anne"], ["Charles"], ["Martin"]]} = Server.query(query)
     end
 
     test "is able to match associations and apply filters" do
-      Server.transaction(fn conn ->
-        Server.query(conn, """
+      Server.query("""
           CREATE (acme:Company {name: "Acme"}),
                  (marvel:Company {name: "Marvel"}),
                  (justin:Person {name:"Justin"}),
@@ -106,18 +103,18 @@ defmodule Integration.QueryingTest do
                  (anne:Person {name:"Anne"})-[:WORKS_IN]->(acme),
                  (hiro:Person {name:"Hiro"})-[:WORKS_IN]->(marvel),
                  (charles:Person {name:"Charles"})-[:WORKS_IN]->(acme)
-        """)
+          """)
 
-        query =
-          cypher do
-            match((node(:person, [:Person]) -- rel([:WORKS_IN]) -> node(:company, [:Company])))
-            where(company.name == "Acme")
-            return(person.name)
-            order({person.name, :asc})
-          end
+      query =
+        cypher do
+          match((node(:person, [:Person]) -- rel([:WORKS_IN]) -> node(:company, [:Company])))
+          where(company.name == "Acme")
+          return(person.name)
+          order({person.name, :asc})
+        end
 
-        assert %{records: [["Anne"], ["Charles"], ["Martin"]]} = Server.query(conn, query)
-      end)
+      assert %{records: [["Anne"], ["Charles"], ["Martin"]]} =
+        Server.query(query)
     end
   end
 end

--- a/test/integration/querying_test.exs
+++ b/test/integration/querying_test.exs
@@ -18,9 +18,9 @@ defmodule Integration.QueryingTest do
   describe "querying stuff in neo4j" do
     test "is able to fetch nodes using MATCH queries" do
       Server.query("""
-          CREATE (:Person {name:"Bob"}), (:Person {name:"Ellie"}),
-                 (:Person {name:"Mark"}), (:Person {name:"Jane"})
-        """)
+        CREATE (:Person {name:"Bob"}), (:Person {name:"Ellie"}),
+               (:Person {name:"Mark"}), (:Person {name:"Jane"})
+      """)
 
       query =
         cypher do
@@ -29,18 +29,17 @@ defmodule Integration.QueryingTest do
           order({p.name, :asc})
         end
 
-      assert %{records: [["Bob"], ["Ellie"], ["Jane"], ["Mark"]]} =
-        Server.query(query)
+      assert %{records: [["Bob"], ["Ellie"], ["Jane"], ["Mark"]]} = Server.query(query)
     end
 
     test "is able to filter nodes" do
       Server.query("""
-          CREATE (:Person {name:"Bob", age:42}),
-                 (:Person {name:"Peter", age:35}),
-                 (:Person {name:"Lucy", age:35}),
-                 (:Person {name:"Anne", age:18}),
-                 (:Person {name:"Mary", age:25})
-        """)
+        CREATE (:Person {name:"Bob", age:42}),
+               (:Person {name:"Peter", age:35}),
+               (:Person {name:"Lucy", age:35}),
+               (:Person {name:"Anne", age:18}),
+               (:Person {name:"Mary", age:25})
+      """)
 
       query =
         cypher do
@@ -56,10 +55,10 @@ defmodule Integration.QueryingTest do
 
     test "is able to filter required nodes with different labels" do
       Server.query("""
-          CREATE (:Droid {name:"R2-D2"}),
-                 (:Droid {name:"C3PO"}),
-                 (:Cyborg {name:"Arnold"})
-        """)
+        CREATE (:Droid {name:"R2-D2"}),
+               (:Droid {name:"C3PO"}),
+               (:Cyborg {name:"Arnold"})
+      """)
 
       query =
         cypher do
@@ -73,13 +72,13 @@ defmodule Integration.QueryingTest do
 
     test "is able to match associations" do
       Server.query("""
-          CREATE (acme:Company {name: "Acme"}),
-                 (marvel:Company {name: "Marvel"}),
-                 (martin:Person {name:"Martin"})-[:WORKS_IN]->(acme),
-                 (anne:Person {name:"Anne"})-[:WORKS_IN]->(acme),
-                 (hiro:Person {name:"Hiro"})-[:WORKS_IN]->(marvel),
-                 (charles:Person {name:"Charles"})-[:WORKS_IN]->(acme)
-          """)
+      CREATE (acme:Company {name: "Acme"}),
+             (marvel:Company {name: "Marvel"}),
+             (martin:Person {name:"Martin"})-[:WORKS_IN]->(acme),
+             (anne:Person {name:"Anne"})-[:WORKS_IN]->(acme),
+             (hiro:Person {name:"Hiro"})-[:WORKS_IN]->(marvel),
+             (charles:Person {name:"Charles"})-[:WORKS_IN]->(acme)
+      """)
 
       query =
         cypher do
@@ -96,14 +95,14 @@ defmodule Integration.QueryingTest do
 
     test "is able to match associations and apply filters" do
       Server.query("""
-          CREATE (acme:Company {name: "Acme"}),
-                 (marvel:Company {name: "Marvel"}),
-                 (justin:Person {name:"Justin"}),
-                 (martin:Person {name:"Martin"})-[:WORKS_IN]->(acme),
-                 (anne:Person {name:"Anne"})-[:WORKS_IN]->(acme),
-                 (hiro:Person {name:"Hiro"})-[:WORKS_IN]->(marvel),
-                 (charles:Person {name:"Charles"})-[:WORKS_IN]->(acme)
-          """)
+      CREATE (acme:Company {name: "Acme"}),
+             (marvel:Company {name: "Marvel"}),
+             (justin:Person {name:"Justin"}),
+             (martin:Person {name:"Martin"})-[:WORKS_IN]->(acme),
+             (anne:Person {name:"Anne"})-[:WORKS_IN]->(acme),
+             (hiro:Person {name:"Hiro"})-[:WORKS_IN]->(marvel),
+             (charles:Person {name:"Charles"})-[:WORKS_IN]->(acme)
+      """)
 
       query =
         cypher do
@@ -113,8 +112,7 @@ defmodule Integration.QueryingTest do
           order({person.name, :asc})
         end
 
-      assert %{records: [["Anne"], ["Charles"], ["Martin"]]} =
-        Server.query(query)
+      assert %{records: [["Anne"], ["Charles"], ["Martin"]]} = Server.query(query)
     end
   end
 end

--- a/test/queries/match_test.exs
+++ b/test/queries/match_test.exs
@@ -45,7 +45,7 @@ defmodule Queries.MatchTest do
           match(node(:bob, [:Person, :Employee]))
         end
 
-      assert "MATCH (bob:Person,Employee)" = query
+      assert "MATCH (bob:Person:Employee)" = query
     end
 
     test "with a name and one prop" do

--- a/test/support/server.ex
+++ b/test/support/server.ex
@@ -1,12 +1,18 @@
 defmodule ExCypher.Support.Server do
   @moduledoc false
 
-  @server_url "http://#{System.get_env("NEO4J_HOST")}:#{System.get_env("NEO4J_PORT")}"
+  @server_url "bolt://#{System.get_env("NEO4J_HOST")}:#{System.get_env("NEO4J_PORT")}"
 
   alias Bolt.Sips, as: Neo
 
   def start_link do
-    {:ok, _pid} = Bolt.Sips.start_link(url: @server_url)
+    {:ok, _} = Application.ensure_all_started(:bolt_sips, :permanent)
+
+    case Bolt.Sips.start_link(url: @server_url) do
+      {:ok, _pid} -> :ok
+      #{:error, {:reason, :already_started}} -> :ok
+      term -> term
+    end
   end
 
   def transaction(function) do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,1 @@
 ExUnit.start()
-Application.start(:bolt_sips)


### PR DESCRIPTION
### What changed?

1. I've fixed the multi-label syntax in cypher queries. The old syntax was using a comma separator for multiple labels, but [cypher docs uses double colon instead](https://neo4j.com/docs/cypher-manual/current/clauses/create/#create-create-a-node-with-multiple-labels)

2. The integration specs were causing a race condition in `bolt_sips` start-up when calling `Bolt.Sips.start_link/0`, which in turn performs a two step validation to check [if `Bolt.Sips.Router` process exists and is alive](https://github.com/florinpatrascu/bolt_sips/blob/b236c2d42cb65cecee966e39515b338643932d69/lib/bolt_sips.ex#L61). However, this can is error prone: if the `Router` process dies after the check-up, the `start_link` fails. So, in order to avoid integration specs `setup_all` block causing random failures, I've opted to force a retry whenever this occurs. 