### PR TITLE
Upgrade elixir minor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         otp: [22.2]
-        elixir: [1.7.4, 1.8.2, 1.9.4, 1.10.0]
+        elixir: [1.7.4, 1.8.2, 1.9.4, 1.10.4]
 
     steps:
     - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.9.4
+FROM elixir:1.10
 
 ARG uid
 ARG workdir=/ex-cypher


### PR DESCRIPTION
Upgrading elixir minor in development environment to 1.10

I'm also updating the github workflows 1.10 patch to the latest one available.
Sadly, we don't have yet 1.11 available yet at dockerhub, so I couldn't upgrade further.