### PR TITLE
Split giant case statement using pattern-matching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,21 +61,21 @@ jobs:
     - name: Run Tests
       run: mix test --only integration:true
 
-  #quality:
-    #runs-on: ubuntu-latest
-    #name: Code Quality
-    #needs: test
+  quality:
+    runs-on: ubuntu-latest
+    name: Code Quality
+    needs: test
 
-    #steps:
-    #- uses: actions/checkout@v2
-    #- uses: actions/setup-elixir@v1
-      #with:
-        #elixir-version: 1.10.0
-        #otp-version: 22.2
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-elixir@v1
+      with:
+        elixir-version: 1.10.0
+        otp-version: 22.2
 
-    #- name: Install Dependencies
-      #run: mix deps.get
-    #- name: Mix format
-      #run: mix format --check-formatted
-    #- name: Mix Credo
-      #run: mix credo --strict
+    - name: Install Dependencies
+      run: mix deps.get
+    - name: Mix format
+      run: mix format --check-formatted
+    - name: Mix Credo
+      run: mix credo --strict

--- a/lib/ex_cypher/statements/generic.ex
+++ b/lib/ex_cypher/statements/generic.ex
@@ -30,7 +30,7 @@ defmodule ExCypher.Statements.Generic do
   # Removing parenthesis from statements that elixir
   # attempts to resolve a name as a function.
   def parse(ast, env) do
-    parse_expression Expression.new(ast, env)
+    parse_expression(Expression.new(ast, env))
   end
 
   defp parse_expression(expr = %Expression{type: :property}) do
@@ -41,7 +41,7 @@ defmodule ExCypher.Statements.Generic do
 
   defp parse_expression(expr = %Expression{type: :fragment}) do
     expr.args
-    |> Enum.map(& parse(&1, expr.env))
+    |> Enum.map(&parse(&1, expr.env))
     |> Enum.map(&String.replace(&1, "\"", ""))
     |> Enum.join(", ")
   end
@@ -55,10 +55,13 @@ defmodule ExCypher.Statements.Generic do
   defp parse_expression(expr = %Expression{type: :association}) do
     [association, {from_type, from}, {to_type, to}] = expr.args
 
-    apply(Relationship, :assoc, [association, {
-      {from_type, parse(from, expr.env)},
-      {to_type, parse(to, expr.env)}
-    }])
+    apply(Relationship, :assoc, [
+      association,
+      {
+        {from_type, parse(from, expr.env)},
+        {to_type, parse(to, expr.env)}
+      }
+    ])
   end
 
   defp parse_expression(%Expression{type: :null}),

--- a/lib/ex_cypher/statements/generic/association.ex
+++ b/lib/ex_cypher/statements/generic/association.ex
@@ -1,0 +1,34 @@
+defmodule ExCypher.Statements.Generic.Association do
+  @moduledoc """
+    Parses the nodes and relationships associations in the AST
+  """
+
+  @associations [:--, :->, :<-]
+
+  # We cannot rely on string manipulation in order to identify whether a given
+  # node represents a node or a relationship as was being made before, 'cause it
+  # can lead to problems when unquoting bound variables.
+  #
+  # It's better to rely on the AST structure itself instead
+  def type(side, ast_node) do
+    case {side, ast_node} do
+      {_side, {:node, _ctx, _args}} ->
+        :node
+
+      {_side, {:rel, _ctx, _args}} ->
+        :relationship
+
+      {:from, {assoc, _ctx, [_from, to | _]}} when assoc in @associations ->
+        type(:from, to)
+
+      {:to, {assoc, _ctx, [from | _]}} when assoc in @associations ->
+        type(:to, from)
+
+      {side, {other, _ctx, _args}} ->
+        type(side, other)
+
+      {side, [term | _rest]} ->
+        type(side, term)
+    end
+  end
+end

--- a/lib/ex_cypher/statements/generic/expression.ex
+++ b/lib/ex_cypher/statements/generic/expression.ex
@@ -3,6 +3,7 @@ defmodule ExCypher.Statements.Generic.Expression do
     A module to abstract the AST format into something mode human-readable
   """
 
+  alias ExCypher.Statements.Generic.Association
   alias ExCypher.Statements.Generic.Variable
 
   defstruct [:type, :env, :args]
@@ -67,9 +68,12 @@ defmodule ExCypher.Statements.Generic.Expression do
   defp as_association({ast, env}) do
     case ast do
       {association, _ctx, [from, to]} ->
+        from_type = Association.type(:from, from)
+        to_type = Association.type(:to, to)
+
         %__MODULE__{
           type: :association,
-          args: [association, {from, to}],
+          args: [association, {from_type, from}, {to_type, to}],
           env: env
         }
       _ ->

--- a/lib/ex_cypher/statements/generic/expression.ex
+++ b/lib/ex_cypher/statements/generic/expression.ex
@@ -60,6 +60,7 @@ defmodule ExCypher.Statements.Generic.Expression do
     case ast do
       {:rel, _ctx, args} ->
         %__MODULE__{type: :relationship, args: parse_args(args), env: env}
+
       _ ->
         nil
     end
@@ -76,6 +77,7 @@ defmodule ExCypher.Statements.Generic.Expression do
           args: [association, {from_type, from}, {to_type, to}],
           env: env
         }
+
       _ ->
         nil
     end


### PR DESCRIPTION
There was a offender when running credo: the `Generic` module had a big `case` statement during the refactoring. Now I was finally able to remove it from the code, and, using pattern-matching on the new `Expression` struct, it renders correctly the `cypher` query string, depending on the `Expression.type`.